### PR TITLE
Add debug output to CreateOrder method

### DIFF
--- a/Ghtk.Api/Controllers/ShipmentServiceController.cs
+++ b/Ghtk.Api/Controllers/ShipmentServiceController.cs
@@ -18,6 +18,7 @@ namespace Ghtk.Api.Controllers
         [Authorize]
         public IActionResult CreateOrder([FromBody] CreateOrder shipment)
         {
+            Console.WriteLine("hahaa");
             return Ok();
         }
     }


### PR DESCRIPTION
Introduced a Console.WriteLine statement in the
CreateOrder method of ShipmentServiceController.cs to print "hahaa" to the console for debugging purposes. This change does not affect the method's return value.